### PR TITLE
feat: Added authentication, authorization with jwt token

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -12,8 +12,11 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="11.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.7" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.21.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/API/Controllers/AuthController.cs
+++ b/API/Controllers/AuthController.cs
@@ -3,6 +3,13 @@ using Infrastructure.Models;
 using Microsoft.AspNetCore.Identity;
 using API.Models;
 using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+using Application.JwtTokenService;
 
 namespace API.Controllers
 {
@@ -10,43 +17,39 @@ namespace API.Controllers
     [Route("api/[controller]")]
     public class AuthController : Controller
     {
-        private SignInManager<ApplicationUser> _signInManager;
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly IMapper _mapper;
-        public AuthController(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager, IMapper mapper) {
+        private readonly IJwtTokenService _tokenService;
+
+        public AuthController(UserManager<ApplicationUser> userManager, IMapper mapper, IJwtTokenService tokenService) {
             _userManager = userManager;
             _mapper = mapper;
+            _tokenService = tokenService;
         }
 
-        //[HttpPost("[action]")]
-        //public async Task<IActionResult> Register(UserDto user)
-        //{
-        //    var userApp = _mapper.Map<ApplicationUser>(user);
-
-        //    IdentityResult result = await _userManager.CreateAsync(userApp, user.Password);
-        //    return Ok();
-        //}
-
-        /*
-         [HttpPost]
-        [AllowAnonymous]
-        [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Login([Required][EmailAddress] string email, [Required] string password, string returnurl)
+        [HttpPost("[action]")]
+        public async Task<IActionResult> Register(UserDto user)
         {
-                ApplicationUser appUser = await userManager.FindByEmailAsync(email);
-                if (appUser != null)
-                {
-                    Microsoft.AspNetCore.Identity.SignInResult result = await signInManager.PasswordSignInAsync(appUser, password, false, false);
-                    if (result.Succeeded)
-                    {
-                        return Redirect(returnurl ?? "/");
-                    }
-                }
-                ModelState.AddModelError(nameof(email), "Login Failed: Invalid Email or Password");
-            
-         
-            return View();
+            var userApp = _mapper.Map<ApplicationUser>(user);
+
+            IdentityResult result = await _userManager.CreateAsync(userApp, user.Password);
+            return Ok();
         }
-         */
+
+        [HttpPost]
+        [AllowAnonymous]
+        public async Task<IActionResult> Login([Required][EmailAddress] string email, [Required] string password)
+        {
+            ApplicationUser user = await _userManager.FindByEmailAsync(email);
+            if (user != null && await _userManager.CheckPasswordAsync(user, password))
+            {
+                var userRoles = await _userManager.GetRolesAsync(user);
+
+                var token = _tokenService.CreateUserToken(user, userRoles);
+
+                return Ok(token);
+            }
+            return Unauthorized();
+        }
     }
 }

--- a/API/Controllers/WeatherForecastController.cs
+++ b/API/Controllers/WeatherForecastController.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace JWTAuthentication.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    public class WeatherForecastController : ControllerBase
+    {
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        private readonly ILogger<WeatherForecastController> _logger;
+
+        public WeatherForecastController(ILogger<WeatherForecastController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public IEnumerable<WeatherForecast> Get()
+        {
+            var rng = new Random();
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = rng.Next(-20, 55),
+                Summary = Summaries[rng.Next(Summaries.Length)]
+            })
+            .ToArray();
+        }
+    }
+}

--- a/API/JwtTokenService/AppSettings.cs
+++ b/API/JwtTokenService/AppSettings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.JwtTokenService
+{
+    public class AppSettings : IAppSettings
+    {
+        public string Token { get; set; }
+    }
+}

--- a/API/JwtTokenService/IAppSettings.cs
+++ b/API/JwtTokenService/IAppSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace Application.JwtTokenService
+{
+    public interface IAppSettings
+    {
+        string Token { get; set; }
+    }
+}

--- a/API/JwtTokenService/IJwtTokenService.cs
+++ b/API/JwtTokenService/IJwtTokenService.cs
@@ -1,0 +1,10 @@
+﻿using Domain.Models;
+using Infrastructure.Models;
+
+namespace Application.JwtTokenService
+{
+    public interface IJwtTokenService
+    {
+        string CreateUserToken(ApplicationUser user,  IList<string> userRoles);
+    }
+}

--- a/API/JwtTokenService/JwtTokenService.cs
+++ b/API/JwtTokenService/JwtTokenService.cs
@@ -1,0 +1,51 @@
+﻿using Domain.Models;
+using Infrastructure.Models;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Application.JwtTokenService
+{
+    public class JwtTokenService : IJwtTokenService
+    {
+        private readonly IAppSettings _appSettings;
+
+        public JwtTokenService(IOptions<AppSettings> appSettings)
+        {
+            _appSettings = appSettings.Value;
+        }
+        public string CreateUserToken(ApplicationUser user, IList<string> userRoles)
+        {
+            //this piece of code was taken from tutorial https://www.youtube.com/watch?v=TDY_DtTEkes&t=245s
+            List<Claim> claims = new List<Claim>
+                        {
+                            new Claim(ClaimTypes.Email, user.Email)
+                        };
+
+            foreach (var userRole in userRoles)
+            {
+                claims.Add(new Claim(ClaimTypes.Role, userRole));
+            }
+
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(
+                _appSettings.Token));
+
+            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha512Signature);
+
+            var token = new JwtSecurityToken(
+                claims: claims,
+                expires: DateTime.Now.AddDays(1),
+                signingCredentials: creds);
+
+            var jwt = new JwtSecurityTokenHandler().WriteToken(token);
+
+            return jwt;
+        }
+    }
+}

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1,15 +1,64 @@
 using API.Mapping;
 using API.Settings;
+using Application.JwtTokenService;
 using Infrastructure.Models;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Filters;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
 builder.Services.AddControllers();
+
+//This is for jwttokenservice, so jwttokenservice can get the token from appsettings
+builder.Services.Configure<AppSettings>(builder.Configuration.GetSection("appsettings"));
+
+builder.Services.AddScoped<IAppSettings, AppSettings>();
+builder.Services.AddScoped<IJwtTokenService, JwtTokenService>();
+
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+
+builder.Services.AddSwaggerGen(options => {
+    options.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
+    {
+        Description = "Standard Authorization header using the Bearer scheme (\"bearer {token}\")",
+        In = ParameterLocation.Header,
+        Name = "Authorization",
+        Type = SecuritySchemeType.ApiKey
+    });
+
+    options.OperationFilter<SecurityRequirementsOperationFilter>();
+});
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8
+                .GetBytes(builder.Configuration.GetSection("AppSettings:Token").Value)),
+            ValidateIssuer = false,
+            ValidateAudience = false
+        };
+    });
+
+//Without this we would have to use [Authorize(AuthenticationSchemes = "Bearer")]
+//when setting authorized fields in controllers
+//We are using jwt token authorization.
+builder.Services.AddAuthorization(options =>
+{
+    var defaultAuthorizationPolicyBuilder = new AuthorizationPolicyBuilder(
+        JwtBearerDefaults.AuthenticationScheme);
+    defaultAuthorizationPolicyBuilder =
+        defaultAuthorizationPolicyBuilder.RequireAuthenticatedUser();
+    options.DefaultPolicy = defaultAuthorizationPolicyBuilder.Build();
+});
 
 // Add Identity
 var mongoDbSettings = builder.Configuration.GetSection(nameof(MongoDbConfig)).Get<MongoDbConfig>();
@@ -26,6 +75,7 @@ builder.Services.AddIdentity<ApplicationUser, ApplicationRole>(opt =>
         mongoDbSettings.ConnectionString, mongoDbSettings.Name
     );
 builder.Services.AddAutoMapper(typeof(MappingProfile));
+
 
 var app = builder.Build();
 

--- a/API/WeatherForecast.cs
+++ b/API/WeatherForecast.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace JWTAuthentication
+{
+    public class WeatherForecast
+    {
+        public DateTime Date { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+        public string Summary { get; set; }
+    }
+}

--- a/API/appsettings.json
+++ b/API/appsettings.json
@@ -5,6 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "AppSettings": {
+    "Token": "Secret key name, !@#ER!@D https://www.youtube.com/watch?v=dQw4w9WgXcQ "
+  },
   "AllowedHosts": "*",
   "MongoDbConfig": {
     "Name": "Exadel-Budget",

--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -1,10 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.21.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.21.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />


### PR DESCRIPTION
Authorization and logging in is done with jwt token.
Microsoft identity was only used to get userManager service. Didn't use singInManager as didn't see a point to it right now.
Weather forecast was added to test authorization.
JwtTokenService creates a jwt token, didn't want the controller to do the work. I was not sure where it should be placed so just left it in a folder in API project.

I am not very familiar with "microsoft identity" so I could have not used some of its features that should be used. So please take a look at the code. I know the code is smelly, sorry (×_×#)