### PR TITLE
#187-create-cqrs-operations-for-currencyrates-model

### DIFF
--- a/src/BudgetManager.Shared/BudgetManager.Shared.DataAccess.MongoDB/BaseImplementation/BaseRepository.cs
+++ b/src/BudgetManager.Shared/BudgetManager.Shared.DataAccess.MongoDB/BaseImplementation/BaseRepository.cs
@@ -76,6 +76,18 @@ namespace BudgetManager.Shared.DataAccess.MongoDB.BaseImplementation
             return await _collection.FindOneAndReplaceAsync(filter, document, options, cancellationToken);
         }
 
+        public virtual async Task<TDocument> UpsertAsync(TDocument document, CancellationToken cancellationToken)
+        {
+            var options = new FindOneAndReplaceOptions<TDocument>
+            {
+                ReturnDocument = ReturnDocument.After,
+                IsUpsert = true,
+            };
+            var filter = Builders<TDocument>.Filter.Eq(doc => doc.Id, document.Id);
+
+            return await _collection.FindOneAndReplaceAsync(filter, document, options, cancellationToken);
+        }
+
         public virtual async Task<TDocument> UpdateOneAsync(Expression<Func<TDocument, bool>> filterExpression,
             UpdateDefinition<TDocument> updateDefinition, CancellationToken cancellationToken)
         {
@@ -98,7 +110,7 @@ namespace BudgetManager.Shared.DataAccess.MongoDB.BaseImplementation
             return deleteResult is not null;
         }
 
-        public virtual async Task<bool> DeleteOneAsync(Expression<Func<TDocument, bool>> filterExpression, CancellationToken cancellationToken)
+        public virtual async Task<bool> DeleteOneAsync(FilterDefinition<TDocument> filterExpression, CancellationToken cancellationToken)
         {
             var deleteResult = await _collection.FindOneAndDeleteAsync(filterExpression, null, cancellationToken);
 

--- a/src/BudgetManager.Shared/BudgetManager.Shared.DataAccess.MongoDB/BaseImplementation/IBaseRepository.cs
+++ b/src/BudgetManager.Shared/BudgetManager.Shared.DataAccess.MongoDB/BaseImplementation/IBaseRepository.cs
@@ -23,6 +23,7 @@ namespace BudgetManager.Shared.DataAccess.MongoDB.BaseImplementation
         Task<TDocument> FindByIdAsync(Guid id, CancellationToken cancellationToken);
 
         Task<TDocument> ReplaceOneAsync(TDocument document, CancellationToken cancellationToken);
+        Task<TDocument> UpsertAsync(TDocument document, CancellationToken cancellationToken);
         Task<TDocument> UpdateOneAsync(Expression<Func<TDocument, bool>> filterExpression,
             UpdateDefinition<TDocument> updateDefinition, CancellationToken cancellationToken);
         Task<TDocument> UpdateOneAsync(FilterDefinition<TDocument> filterExpression,
@@ -30,6 +31,6 @@ namespace BudgetManager.Shared.DataAccess.MongoDB.BaseImplementation
 
         Task<bool> DeleteByIdAsync(Guid id, CancellationToken cancellationToken);
 
-        Task<bool> DeleteOneAsync(Expression<Func<TDocument, bool>> filterExpression, CancellationToken cancellationToken);
+        Task<bool> DeleteOneAsync(FilterDefinition<TDocument> filterExpression, CancellationToken cancellationToken);
     }
 }

--- a/src/BudgetManager/BudgetManager.API/Program.cs
+++ b/src/BudgetManager/BudgetManager.API/Program.cs
@@ -39,6 +39,7 @@ builder.Services.AddScoped<IBaseRepository<Notification>, NotificationRepository
 builder.Services.AddScoped<IBaseRepository<Country>, CountryRepository>();
 builder.Services.AddScoped<IBaseRepository<Currency>, CurrencyRepository>();
 builder.Services.AddScoped<IBaseRepository<DefaultCategory>, DefaultCategoryRepository>();
+builder.Services.AddScoped<IBaseRepository<CurrencyRates>, CurrencyRatesRepository>();
 builder.Services.AddScoped<ITransactionRepository, TransactionRepository>();
 
 builder.Services.AddScoped<ISeedingService, SeedingService>();

--- a/src/BudgetManager/BudgetManager.CQRS/Commands/CurrencyRatesCommands/UpdateCurrencyRates.cs
+++ b/src/BudgetManager/BudgetManager.CQRS/Commands/CurrencyRatesCommands/UpdateCurrencyRates.cs
@@ -1,0 +1,12 @@
+﻿using BudgetManager.Model;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BudgetManager.CQRS.Commands.CurrencyRatesCommands
+{
+    public record UpdateCurrencyRatesCommand(CurrencyRates CurrencyRates) : IRequest;
+}

--- a/src/BudgetManager/BudgetManager.CQRS/Handlers/CurrencyRatesHandlers/GetCurrencyRatesHandler.cs
+++ b/src/BudgetManager/BudgetManager.CQRS/Handlers/CurrencyRatesHandlers/GetCurrencyRatesHandler.cs
@@ -1,0 +1,31 @@
+﻿using AutoMapper;
+using BudgetManager.CQRS.Queries.CurrencyRatesQueries;
+using BudgetManager.Model;
+using BudgetManager.Shared.DataAccess.MongoDB.BaseImplementation;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BudgetManager.CQRS.Handlers.CurrencyRatesHandlers
+{
+    public class GetCurrencyRatesHandler : IRequestHandler<GetCurrencyRatesQuery, CurrencyRates>
+    {
+        private readonly IMapper _mapper;
+        private readonly IBaseRepository<CurrencyRates> _dataAccess;
+
+        public GetCurrencyRatesHandler(IMapper mapper, IBaseRepository<CurrencyRates> dataAccess)
+        {
+            _mapper = mapper;
+            _dataAccess = dataAccess;
+        }
+
+        public async Task<CurrencyRates> Handle(GetCurrencyRatesQuery request, CancellationToken cancellationToken)
+        {
+            var result = (await _dataAccess.GetAllAsync(CancellationToken.None)).FirstOrDefault();
+            return result;
+        }
+    }
+}

--- a/src/BudgetManager/BudgetManager.CQRS/Handlers/CurrencyRatesHandlers/UpdateCurrencyRatesHandler.cs
+++ b/src/BudgetManager/BudgetManager.CQRS/Handlers/CurrencyRatesHandlers/UpdateCurrencyRatesHandler.cs
@@ -1,0 +1,24 @@
+﻿using BudgetManager.CQRS.Commands.CurrencyRatesCommands;
+using BudgetManager.Model;
+using BudgetManager.Shared.DataAccess.MongoDB.BaseImplementation;
+using MediatR;
+using MongoDB.Driver;
+
+namespace BudgetManager.CQRS.Handlers.CurrencyRatesHandlers
+{
+    public class UpdateCurrencyRatesHandler : IRequestHandler<UpdateCurrencyRatesCommand>
+    {
+        private readonly IBaseRepository<CurrencyRates> _dataAccess;
+
+        public UpdateCurrencyRatesHandler(IBaseRepository<CurrencyRates> dataAccess)
+        {
+            _dataAccess = dataAccess;
+        }
+
+        public async Task<Unit> Handle(UpdateCurrencyRatesCommand request, CancellationToken cancellationToken)
+        {
+            await _dataAccess.UpsertAsync(request.CurrencyRates, CancellationToken.None);
+            return Unit.Value;
+        }
+    }
+}

--- a/src/BudgetManager/BudgetManager.CQRS/Queries/CurrencyRatesQueries/GetCurrencyRatesQuery.cs
+++ b/src/BudgetManager/BudgetManager.CQRS/Queries/CurrencyRatesQueries/GetCurrencyRatesQuery.cs
@@ -1,0 +1,12 @@
+﻿using BudgetManager.Model;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BudgetManager.CQRS.Queries.CurrencyRatesQueries
+{
+    public record GetCurrencyRatesQuery() : IRequest<CurrencyRates>;
+}

--- a/src/BudgetManager/BudgetManager.DataAccess/MongoDbAccess/Repositories/CurrencyRatesRepository.cs
+++ b/src/BudgetManager/BudgetManager.DataAccess/MongoDbAccess/Repositories/CurrencyRatesRepository.cs
@@ -1,0 +1,15 @@
+﻿using BudgetManager.Model;
+using BudgetManager.Shared.DataAccess.MongoDB.BaseImplementation;
+using BudgetManager.Shared.DataAccess.MongoDB.DatabaseSettings;
+using MongoDB.Driver;
+
+namespace BudgetManager.DataAccess.MongoDbAccess.Repositories
+{
+    public class CurrencyRatesRepository : BaseRepository<CurrencyRates>
+    {
+        public CurrencyRatesRepository(IMongoDbSettings settings, IMongoClient client)
+            : base(settings, client)
+        {
+        }
+    }
+}

--- a/src/BudgetManager/BudgetManager.Model/CurrencyRates.cs
+++ b/src/BudgetManager/BudgetManager.Model/CurrencyRates.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using BudgetManager.Shared.Models.MongoDB.Models.Interfaces;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDbGenericRepository.Attributes;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace BudgetManager.Model
+{
+    [CollectionName("CurrencyRates")]
+    public class CurrencyRates : IModelBase
+    {
+        [JsonIgnore]
+        [BsonId]
+        public Guid Id { get; set; } = new Guid("66c05d55-dc7a-4d91-a965-a037db973b06");
+
+        [JsonProperty("date")]
+        public DateTimeOffset Date { get; set; }
+
+        // Eur is used as a base for currency rates
+        [JsonProperty("eur")]
+        public Dictionary<string, double> Eur { get; set; }
+    }
+}


### PR DESCRIPTION
Created CurrencyRates model and CQRS operations.
Added another method to BaseRepository for upserting.
The CurrencyRates will only have one document, it will be an entity that has a date of when the rates were updated and Dictionary of all the currencies with their rates, using EUR as a base.
The Id will always remain the same as there will only ever be one entity, plus it makes it easier to do upserting.